### PR TITLE
Fixed wrong parameter name

### DIFF
--- a/packages/edge-boilerplate/src/State.js
+++ b/packages/edge-boilerplate/src/State.js
@@ -12,7 +12,7 @@ export default {
   getConfig(state, topic) {
     if (topic === "apollo") {
       return {
-        url: state.env.APOLLO_URL
+        uri: state.env.APOLLO_URL
 
         // headers: {},
         // batchRequests: false,


### PR DESCRIPTION
The createApolloClient in edge-core expects the parameter to be called uri, not url.