### PR TITLE
Fix #3 copy url to clipboard

### DIFF
--- a/packages/edge-builder/package.json
+++ b/packages/edge-builder/package.json
@@ -35,6 +35,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "chalk": "^2.3.1",
     "css-loader": "^0.28.10",
+    "edge-common": "^0.1.5",
     "extract-css-chunks-webpack-plugin": "^2.0.18",
     "file-loader": "^1.1.10",
     "fs-extra": "^5.0.0",

--- a/packages/edge-builder/package.json
+++ b/packages/edge-builder/package.json
@@ -34,6 +34,7 @@
     "cache-loader": "^1.2.2",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "chalk": "^2.3.1",
+    "clipboardy": "^1.2.3",
     "css-loader": "^0.28.10",
     "edge-common": "^0.1.5",
     "extract-css-chunks-webpack-plugin": "^2.0.18",

--- a/packages/edge-builder/src/webpack/dev.js
+++ b/packages/edge-builder/src/webpack/dev.js
@@ -4,6 +4,7 @@ import webpackDevMiddleware from "webpack-dev-middleware"
 import webpackHotMiddleware from "webpack-hot-middleware"
 import webpackHotServerMiddleware from "webpack-hot-server-middleware"
 import { notify } from "edge-common"
+import clipboardy from "clipboardy"
 
 import configBuilder from "../builder"
 
@@ -72,6 +73,12 @@ export function connectWithWebpack(server, multiCompiler) {
 
       server.listen(process.env.SERVER_PORT, () => {
         notify(`Server started at port ${process.env.SERVER_PORT}`, "info")
+
+        clipboardy
+          .write(`http://localhost:${process.env.SERVER_PORT}`)
+          .catch((error) => {
+            // noop
+          })
       })
     }
   })


### PR DESCRIPTION
This fixes issue #3 copying dev server URL to clipboard when dev server starts. In environments where clipboard is not available this copy to clipboard silently fails which is per intention.