### PR TITLE
Replace shrink-ray with compression

### DIFF
--- a/packages/edge-express/package.json
+++ b/packages/edge-express/package.json
@@ -29,6 +29,7 @@
     "app-root-dir": "^1.0.2",
     "body-parser": "^1.18.2",
     "chalk": "^2.3.1",
+    "compression": "^1.7.2",
     "cookie-parser": "^1.4.3",
     "cosmiconfig": "^4.0.0",
     "dotenv": "^5.0.1",
@@ -38,7 +39,6 @@
     "hpp": "^0.2.2",
     "jsome": "^2.5.0",
     "pretty-error": "^2.1.1",
-    "shrink-ray": "^0.1.3",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/edge-express/src/addCoreMiddleware.js
+++ b/packages/edge-express/src/addCoreMiddleware.js
@@ -1,4 +1,4 @@
-import shrinkRay from "shrink-ray"
+import compression from "compression"
 import createLocaleMiddleware from "express-locale"
 import cookieParser from "cookie-parser"
 import bodyParser from "body-parser"
@@ -22,7 +22,6 @@ export default function addCoreMiddleware(server, { locale }) {
   // Parse application/json
   server.use(bodyParser.json())
 
-  // Advanced response compression using a async zopfli/brotli combination
-  // https://github.com/aickin/shrink-ray
-  server.use(shrinkRay())
+  // Compress output stream
+  server.use(compression())
 }


### PR DESCRIPTION
# Purpose of this PR:
1. Replace native bindings to C code with code that runs entirely in node
2. Both zopfli and brotli are no good fit for fastest time to first byte and overall request time
3. shrink-ray caches files in memory which might lead to high memory consumption

## On 1.
Having native bindings is an issue when you want to deploy on function as a service engines lika AWS Lambda. node_modules have to be moved to Lambda and Lambda is running on AWS Linux. So this means a deploy can only happen from linux machines with exact same architecture. There is a wasm port of brotli, but this one don't support streaming.

## On 2.
Both algorithms are not meant to be done in web request streams. They are more than 80x slower which leads to a big time overhead.

## On 3.
In most cases the better architecture is to have a caching CDN in front of the webserver.

#  Changes
This PR replaces shrink-ray with compression